### PR TITLE
Fix: namespace error | changed from email to onetimepay

### DIFF
--- a/backend/routes/paid_route.py
+++ b/backend/routes/paid_route.py
@@ -4,7 +4,7 @@ import stripe
 
 
 onetimepay_bp = Blueprint("onetimepay", __name__)
-onetimepay_ns = Namespace("email", description="Onetime payment operations")
+onetimepay_ns = Namespace("onetimepay", description="Onetime payment operations")
 
 
 # Request and response models


### PR DESCRIPTION
Fix: onetimepay_ns = Namespace("email", description="Onetime payment operations")  changed to => onetimepay_ns = Namespace("onetimepay", description="Onetime payment operations") 
